### PR TITLE
Erick/tablesort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ app/assets/images/favicon.ico
 .local/
 mbox
 .viminfo
+.DS_Store

--- a/app/assets/javascripts/tablesort.js
+++ b/app/assets/javascripts/tablesort.js
@@ -2,117 +2,80 @@
 
 /*Setting global variable used to toggle sorting 
 on columns between ascending/descending order*/
-var pcolumn;
-var toggleOn;
+let pcolumn;
+let toggleOn;
+
+function compare(a, b) {
+    if (a.text < b.text)  return -1;
+    if (a.text > b.text) {
+        a.node.parentNode.insertBefore(b.node, a.node);
+        return 1;
+    }
+    return 0;
+}
+
+
+function parseBool(stringVal) {
+    return !(stringVal === false || stringVal === "false")
+}
 
 function tableSort(column) {
-	var table, rows, switching, i, x, y, shouldSwitch;
-  
-	table = document.getElementById("tablesort");
-  
-  
-	switching = true;
-	while (switching) {
-		/*exit the while loop if later 
-		logic doesn't set it to continue*/
-		switching = false;
-    
+    const rows = Array.from($("#tablesort").rows);
+    const shortenedRows = rows.slice(1, rows.length - 1);
 
-		rows = table.getElementsByTagName("TR");
-		/*Loop through each row for sorting (except 
-		for the footer and header rows)*/
-		for (i = 1; i < (rows.length - 2); i++) {
-			//Don't switch rows unless later logic sets it
-		shouldSwitch = false;
-			/*Get the two elements you want to compare,
-			one from current row and one from the next*/
-			x = rows[i].getElementsByTagName("TD")[column];
-			if (x == null){
-				x = document.createTextNode("0");
-			}
-			y = rows[i + 1].getElementsByTagName("TD")[column];
-			if (y == null){
-				y = document.createTextNode("0");
-			}
-			// If column content starts with digits sort numerically
-			if (/^\d/.test(parseFloat(x.textContent))){
-			//check if the two rows should switch places
-				if (parseFloat(x.textContent) > parseFloat(y.textContent)) {
-					//if so, mark to switch and break the for loop
-					shouldSwitch = true;
-					break;
-				}
-			// otherwise sort alphabetically	
-			} else {
-				//check if the two rows should switch places
-				if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
-					//if so, mark to switch and break the for loop
-					shouldSwitch= true;
-					break;
-				}
-			}
-		}
-		if (shouldSwitch) {
-			//make the switch and mark the while loop for another go
-			rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
-			switching = true;
-		}
-	}
+    shortenedRows.map((row) => {
+        return {
+         "node": row.cells[column],
+         "text": row.cells[column].textContent
+        }   
+    }).sort(compare)
+
 	/* if the same column was clicked twice use toggling
 	to go back and forth between ascending and descending
 	order instead of sorting over and over */
-	if (pcolumn == column){
-		if (!toggleOn) {
-			// Set the pcolumn cookie
- 			document.cookie = "pcolumn=" + pcolumn;
- 			// reverse the order of the sorting
- 			listrows = table.getElementsByTagName("TR");
-			pnode = listrows[1].parentNode;
-			rows = $.makeArray(listrows).reverse();
-			for (i = 1; i < (listrows.length - 1); i++) {
-				pnode.removeChild(listrows[i]);
-			}
-			for (i = 1; i < (rows.length - 1); i++) {
-				pnode.appendChild(rows[i]);
-			}
+	if (pcolumn == column && !toggleOn){
+		// Set the pcolumn cookie
+ 		document.cookie = `pcolumn=${pcolumn}`;
+        $("#tablesort")
+ 		// reverse the order of the sorting
+ 		listrows = table.getElementsByTagName("TR");
+		pnode = listrows[1].parentNode;
+		rows = $.makeArray(listrows).reverse();
+		for (i = 1; i < (listrows.length - 1); i++) {
+			pnode.removeChild(listrows[i]);
+		}
+		for (i = 1; i < (rows.length - 1); i++) {
+			pnode.appendChild(rows[i]);
 		}
 	}
 }
 
-function readCookie(name){
-	var nameEQ = name + "=";
-	var ca = document.cookie.split(';');
-	for(var i=0;i < ca.length;i++) {
-		var c = ca[i];
-		while (c.charAt(0)==' ') c = c.substring(1,c.length);
-		if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
-	}
-	return null;
+function readCookie(name){;
+	const cookieArray = document.cookie.split(';');
+    
+    return cookieArray.reduce((retVal, cookie) => {
+        if (cookie.trim().startsWith(name)) retVal = cookie.trim().split("=")[1];
+        return retVal;
+    }, null);    
 }
 
 document.addEventListener("page:change", function(){
-	if($('#index').length){
+	if ($('#index')) {
 		// Use cookies to initially sort table
-		var columnCookie = readCookie("column");
-		var pcolumnCookie = readCookie("pcolumn");
-		pcolumn = pcolumnCookie;
+		pcolumn = readCookie("pcolumn");
+
 		// change the cookie string back into a boolean
-		var toggleCookie = readCookie("toggleOn");
-		if (toggleCookie == "false"){ 
-			toggleOn = false;
-		} else {
-			toggleOn = true;
-		}
-		tableSort(columnCookie);
+        toggleOn = parseBool(readCookie("toggleOn"));
+		tableSort(readCookie("column"));
 
  		$(".thsortable").click( function(){
 			column = $(this).index();
 			// set cookie for column
-			document.cookie = "column=" + column;
+			document.cookie = `column=${column}`;
 			// toggle sorting on click
 			toggleOn = !toggleOn;
 			// set toggle cookie
-			document.cookie = "toggleOn=" + toggleOn;
+			document.cookie = `toggleOn=${toggleOn}`;
 			tableSort(column);
 			// After sorting set previous column
 			pcolumn = column;

--- a/app/assets/javascripts/tablesort.js
+++ b/app/assets/javascripts/tablesort.js
@@ -11,7 +11,7 @@ function parseBool(stringVal) {
 
 function tableSort(column) {
     const rows = Array.from($("#tablesort").rows);
-    const shortenedRows = rows.slice(1, rows.length - 1);
+    const shortenedRows = rows.slice(1, rows.length - 2);
     
     const sortedText = shortenedRows.map((row) => {
          return row.cells[column].textContent;

--- a/app/assets/javascripts/tablesort.js
+++ b/app/assets/javascripts/tablesort.js
@@ -5,52 +5,35 @@ on columns between ascending/descending order*/
 let pcolumn;
 let toggleOn;
 
-function compare(a, b) {
-    if (a.text < b.text)  return -1;
-    if (a.text > b.text) {
-        a.node.parentNode.insertBefore(b.node, a.node);
-        return 1;
-    }
-    return 0;
-}
-
-
 function parseBool(stringVal) {
-    return !(stringVal === false || stringVal === "false")
+    return !(stringVal === false || stringVal === "false");
 }
 
 function tableSort(column) {
     const rows = Array.from($("#tablesort").rows);
     const shortenedRows = rows.slice(1, rows.length - 1);
-
-    shortenedRows.map((row) => {
-        return {
-         "node": row.cells[column],
-         "text": row.cells[column].textContent
-        }   
-    }).sort(compare)
+    
+    const sortedText = shortenedRows.map((row) => {
+         return row.cells[column].textContent;
+    }).sort();
+    
+    shortenedRows.map((row, index) => {
+        row.cells[column].textContent = sortedText[index];
+    });
 
 	/* if the same column was clicked twice use toggling
 	to go back and forth between ascending and descending
 	order instead of sorting over and over */
-	if (pcolumn == column && !toggleOn){
-		// Set the pcolumn cookie
+	if ((pcolumn == column) && !toggleOn) {
  		document.cookie = `pcolumn=${pcolumn}`;
-        $("#tablesort")
- 		// reverse the order of the sorting
- 		listrows = table.getElementsByTagName("TR");
-		pnode = listrows[1].parentNode;
-		rows = $.makeArray(listrows).reverse();
-		for (i = 1; i < (listrows.length - 1); i++) {
-			pnode.removeChild(listrows[i]);
-		}
-		for (i = 1; i < (rows.length - 1); i++) {
-			pnode.appendChild(rows[i]);
-		}
+
+        shortenedRows.map((row, index) => {
+            row.cells[column].textContent = sortedText.reverse()[index];
+        });
 	}
 }
 
-function readCookie(name){;
+function readCookie(name) {
 	const cookieArray = document.cookie.split(';');
     
     return cookieArray.reduce((retVal, cookie) => {


### PR DESCRIPTION
# What this changes
This pull request modernizes/standardizes the way the tables are sorted by using ES6'y stuff.
- Maps, maps everywhere. Maps can be used to transform an array into another array (`sortedText` is a good example) as well as making side effects with array values (`.textContent = sortedText[index]`).
- [`reduce()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce?v=b) is handy for boiling down an array of values into one value (specifically in `readCookie()`)
- [`reverse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse) makes an appearance in the reverse sort. Handy for reversing an array. 

And more stuff here and there